### PR TITLE
[RD-008] Fix Dropdown cutting off issue

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -36,15 +36,15 @@ const Dropdown: React.FC<DropdownProps> = ({ icon, options }) => {
     <details className="dropdown" ref={detailsRef}>
       <summary className="dropdown-toggle">{icon}</summary>
       <ul className="dropdown-menu">
-        {options.map((e, idx) => (
+        {options.map((element, idx) => (
           <li
             onClick={() => {
-              e.action();
+              element.action();
               closeDropdown();
             }}
             key={idx}
           >
-            {e.text}
+            {element.text}
           </li>
         ))}
       </ul>

--- a/src/components/ReservationCard/ReservationCard.css
+++ b/src/components/ReservationCard/ReservationCard.css
@@ -2,13 +2,14 @@
   background-color: white;
   border-radius: 6px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+  overflow: visible;
   position: relative;
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .reservation-card:hover {
-  transform: translateY(-2px);
+  /* TODO: Currently this breaks dropdown menu */
+    /* transform: translateY(-2px); */
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 

--- a/src/components/StatusColumn/StatusColumn.css
+++ b/src/components/StatusColumn/StatusColumn.css
@@ -6,7 +6,7 @@
   background-color: #f5f5f5;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .status-header {
@@ -40,7 +40,7 @@
 .reservation-list {
   flex: 1;
   padding: 1rem;
-  overflow-y: auto;
+  overflow: visible;
   display: flex;
   flex-direction: column;
   gap: 1rem;


### PR DESCRIPTION
In this task I've fixed issue with overlaying Dropdown menu over dashboard columns on main screen. Currently this solution provided card onHover effect to be disabled. 

How it was:
<img width="355" alt="Zrzut ekranu 2025-03-18 o 16 14 50" src="https://github.com/user-attachments/assets/bc8c667c-e698-4a38-905d-886898ac45ec" />

How it is:
<img width="432" alt="Zrzut ekranu 2025-03-18 o 16 31 09" src="https://github.com/user-attachments/assets/d67a8e1a-1529-4628-a78d-827f4e2ce4c5" />